### PR TITLE
fix: tela launch cancellation, RPC stability, GetRating hex fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	go.etcd.io/bbolt v1.3.7
 )
 
-replace github.com/deroproject/derohe => github.com/civilware/derohe v0.0.0-20240909003240-fa76d6016cc6
+replace github.com/deroproject/derohe => github.com/DEROFDN/derohe v0.0.0-20260527071132-5cd042e8f541
 
 require (
 	github.com/VictoriaMetrics/metrics v1.23.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/DEROFDN/derohe v0.0.0-20260527071132-5cd042e8f541 h1:Pf7+RZPtNSAsG/59HGd/pON/Bd7tokSQhO1/WfqT9GQ=
+github.com/DEROFDN/derohe v0.0.0-20260527071132-5cd042e8f541/go.mod h1:EWHh1VkXRnCHvyGML98kXhngDFYebmOhk/9kZ1ATJ1c=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/VictoriaMetrics/metrics v1.23.1 h1:/j8DzeJBxSpL2qSIdqnRFLvQQhbJyJbbEi22yMm7oL0=
@@ -27,8 +29,6 @@ github.com/chzyer/test v1.0.0 h1:p3BQDXSxOhOG0P9z6/hGnII4LGiEPOYBhs8asl/fC04=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/civilware/Gnomon v0.0.0-20240403103529-8b2fdb2b3106 h1:9NSEj0KUC/Xlaw7uk/CIswEevheDNojrG6JoMPXv3G8=
 github.com/civilware/Gnomon v0.0.0-20240403103529-8b2fdb2b3106/go.mod h1:B0/D3D/FVqqugHZ0fO0da2AW+5MiO82uGLOZcmS0CFk=
-github.com/civilware/derohe v0.0.0-20240909003240-fa76d6016cc6 h1:hcCFU5eXd7CPu4AXJnaihhzOgC0SNscmQ+nrgDjKaWo=
-github.com/civilware/derohe v0.0.0-20240909003240-fa76d6016cc6/go.mod h1:EWHh1VkXRnCHvyGML98kXhngDFYebmOhk/9kZ1ATJ1c=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/coder/websocket v1.8.12 h1:5bUXkEPPIbewrnkU8LTCLVaxi4N4J8ahufH2vlo4NAo=

--- a/parse.go
+++ b/parse.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	"github.com/deroproject/derohe/dvm"
 	"github.com/deroproject/derohe/rpc"
@@ -163,12 +164,21 @@ func parseINDEXForDOCs(sc dvm.SmartContract) (scids []string) {
 	return
 }
 
-func parseAndCloneINDEXForDOCs(sc dvm.SmartContract, height int64, basePath, endpoint string) (entrypoint, servePath string, err error) {
+func parseAndCloneINDEXForDOCs(sc dvm.SmartContract, height int64, basePath, endpoint string, cancelled ...*atomic.Bool) (entrypoint, servePath string, err error) {
+	var isCancelled *atomic.Bool
+	if len(cancelled) > 0 {
+		isCancelled = cancelled[0]
+	}
+
 	// Parse INDEX SC for valid DOCs
 	for name, function := range sc.Functions {
 		// Find initialize function and parse lines
 		if name == DVM_FUNC_INIT_PRIVATE {
 			for _, line := range function.Lines {
+				if isCancelled != nil && isCancelled.Load() {
+					err = fmt.Errorf("cancelled")
+					return
+				}
 				// Parse the contents of the line
 				for i, parts := range line {
 					if strings.Contains(parts, string(HEADER_DOCUMENT)) {
@@ -180,41 +190,41 @@ func parseAndCloneINDEXForDOCs(sc dvm.SmartContract, height int64, basePath, end
 						var c Cloning
 						_, err = getContractVar(scid, "telaVersion", endpoint)
 						if err != nil {
-							c, err = cloneDOC(scid, parts, basePath, endpoint)
-							if err != nil {
-								return
-							}
+ 							c, err = cloneDOC(scid, parts, basePath, endpoint, cancelled...)
+ 							if err != nil {
+ 								return
+ 							}
 
-							// If DOC is entrypoint set it, and if serving from subDir point to it
-							if isDOC1 {
-								entrypoint = c.Entrypoint
-								servePath = c.ServePath
-							}
-						} else {
-							if isDOC1 {
-								err = fmt.Errorf("cannot use TELA-INDEX as entrypoint for TELA-INDEX")
-								return
-							}
+ 							// If DOC is entrypoint set it, and if serving from subDir point to it
+ 							if isDOC1 {
+ 								entrypoint = c.Entrypoint
+ 								servePath = c.ServePath
+ 							}
+ 						} else {
+ 							if isDOC1 {
+ 								err = fmt.Errorf("cannot use TELA-INDEX as entrypoint for TELA-INDEX")
+ 								return
+ 							}
 
-							var dURL string
-							dURL, err = getContractVar(scid, HEADER_DURL.Trim(), endpoint)
-							if err != nil {
-								err = fmt.Errorf("could not verify TELA-INDEX dURL: %s", err)
-								return
-							}
+ 							var dURL string
+ 							dURL, err = getContractVar(scid, HEADER_DURL.Trim(), endpoint)
+ 							if err != nil {
+ 								err = fmt.Errorf("could not verify TELA-INDEX dURL: %s", err)
+ 								return
+ 							}
 
-							if !strings.HasSuffix(dURL, TAG_LIBRARY) && !strings.HasSuffix(dURL, TAG_DOC_SHARDS) {
-								err = fmt.Errorf("cannot embed TELA-INDEX without %q or %q tag", TAG_LIBRARY, TAG_DOC_SHARDS)
-								return
-							}
+ 							if !strings.HasSuffix(dURL, TAG_LIBRARY) && !strings.HasSuffix(dURL, TAG_DOC_SHARDS) {
+ 								err = fmt.Errorf("cannot embed TELA-INDEX without %q or %q tag", TAG_LIBRARY, TAG_DOC_SHARDS)
+ 								return
+ 							}
 
-							if height > 0 {
-								c, err = cloneINDEXAtCommit(height, scid, "", basePath, endpoint)
-								if err != nil {
-									return
-								}
-							} else {
-								c, err = cloneINDEX(scid, dURL, basePath, endpoint)
+ 							if height > 0 {
+ 								c, err = cloneINDEXAtCommit(height, scid, "", basePath, endpoint, cancelled...)
+ 								if err != nil {
+ 									return
+ 								}
+ 							} else {
+ 								c, err = cloneINDEX(scid, dURL, basePath, endpoint, cancelled...)
 								if err != nil {
 									return
 								}
@@ -230,7 +240,12 @@ func parseAndCloneINDEXForDOCs(sc dvm.SmartContract, height int64, basePath, end
 }
 
 // Parse a TELA-INDEX for DOCs and prepare its content as DocShards to be recreated by ConstructFromShards
-func parseDocShards(sc dvm.SmartContract, path, endpoint string) (docShards [][]byte, recreate, compression string, err error) {
+func parseDocShards(sc dvm.SmartContract, path, endpoint string, cancelled ...*atomic.Bool) (docShards [][]byte, recreate, compression string, err error) {
+	var isCancelled *atomic.Bool
+	if len(cancelled) > 0 {
+		isCancelled = cancelled[0]
+	}
+
 	scids := parseINDEXForDOCs(sc)
 
 	type shardData struct {
@@ -241,6 +256,10 @@ func parseDocShards(sc dvm.SmartContract, path, endpoint string) (docShards [][]
 	var shards []shardData
 
 	for i, scid := range scids {
+		if isCancelled != nil && isCancelled.Load() {
+			err = fmt.Errorf("cancelled")
+			return
+		}
 		if len(scid) != 64 {
 			err = fmt.Errorf("invalid DOC SCID: %s", scid)
 			return

--- a/tela.go
+++ b/tela.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 
@@ -108,6 +109,23 @@ type TELA struct {
 		WS  *websocket.Conn
 		RPC *jrpc2.Client
 	}
+}
+
+var (
+	rpcSem = make(chan struct{}, 16) // Limit total concurrent RPC calls across all TELA operations
+)
+
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "connection") ||
+		strings.Contains(s, "abort") ||
+		strings.Contains(s, "EOF") ||
+		strings.Contains(s, "closed") ||
+		strings.Contains(s, "broken pipe") ||
+		strings.Contains(s, "no such host")
 }
 
 // Versioning structure used for package and contracts
@@ -658,7 +676,15 @@ func isShardFileName(name string) bool {
 }
 
 // Clone a TELA-DOC SCID to path from endpoint
-func cloneDOC(scid, docNum, path, endpoint string) (clone Cloning, err error) {
+func cloneDOC(scid, docNum, path, endpoint string, cancelled ...*atomic.Bool) (clone Cloning, err error) {
+	var isCancelled *atomic.Bool
+	if len(cancelled) > 0 {
+		isCancelled = cancelled[0]
+	}
+
+	if isCancelled != nil && isCancelled.Load() {
+		return clone, fmt.Errorf("cancelled")
+	}
 	if len(scid) != 64 {
 		err = fmt.Errorf("invalid DOC SCID: %s", scid)
 		return
@@ -761,7 +787,15 @@ func cloneDOC(scid, docNum, path, endpoint string) (clone Cloning, err error) {
 }
 
 // Clone a TELA-INDEX SCID to path from endpoint creating all DOCs embedded within the INDEX
-func cloneINDEX(scid, dURL, path, endpoint string) (clone Cloning, err error) {
+func cloneINDEX(scid, dURL, path, endpoint string, cancelled ...*atomic.Bool) (clone Cloning, err error) {
+	var isCancelled *atomic.Bool
+	if len(cancelled) > 0 {
+		isCancelled = cancelled[0]
+	}
+
+	if isCancelled != nil && isCancelled.Load() {
+		return clone, fmt.Errorf("cancelled")
+	}
 	if len(scid) != 64 {
 		err = fmt.Errorf("invalid INDEX SCID: %s", scid)
 		return
@@ -810,14 +844,14 @@ func cloneINDEX(scid, dURL, path, endpoint string) (clone Cloning, err error) {
 
 	// If INDEX contains DocShards to be constructed
 	if strings.HasSuffix(dURL, TAG_DOC_SHARDS) {
-		err = cloneDocShards(sc, basePath, endpoint)
+		err = cloneDocShards(sc, basePath, endpoint, cancelled...)
 		if err != nil {
 			err = fmt.Errorf("%s %s", tagErr, err)
 			return
 		}
 	} else {
 		// Parse INDEX SC for valid DOCs
-		entrypoint, servePath, err = parseAndCloneINDEXForDOCs(sc, 0, basePath, endpoint)
+		entrypoint, servePath, err = parseAndCloneINDEXForDOCs(sc, 0, basePath, endpoint, cancelled...)
 		if err != nil {
 			// If all of the files were not cloned successfully, any residual files are removed if they did not exist already
 			err = fmt.Errorf("%s %s", tagErr, err)
@@ -837,8 +871,8 @@ func cloneINDEX(scid, dURL, path, endpoint string) (clone Cloning, err error) {
 }
 
 // cloneDocShards takes a TELA-INDEX SC and parses its DOCs, creating them as DocShards which get recreated as a single file
-func cloneDocShards(sc dvm.SmartContract, basePath, endpoint string) (err error) {
-	docShards, recreate, compression, err := parseDocShards(sc, basePath, endpoint)
+func cloneDocShards(sc dvm.SmartContract, basePath, endpoint string, cancelled ...*atomic.Bool) (err error) {
+	docShards, recreate, compression, err := parseDocShards(sc, basePath, endpoint, cancelled...)
 	if err != nil {
 		err = fmt.Errorf("could not clone DocShards: %s", err)
 		return
@@ -1000,8 +1034,16 @@ func CreateShardFiles(filePath, compression string, content []byte) (err error) 
 	return
 }
 
-// Clone a TELA-INDEX SCID at commit TXID to path from endpoint creating all DOCs embedded within the INDEX at the commit height
-func cloneINDEXAtCommit(height int64, scid, txid, path, endpoint string) (clone Cloning, err error) {
+// cloneINDEXAtCommit clones a TELA-INDEX-1 SC from endpoint at commit TXID if the SC code from that commit can be decoded
+func cloneINDEXAtCommit(height int64, scid, txid, path, endpoint string, cancelled ...*atomic.Bool) (clone Cloning, err error) {
+	var isCancelled *atomic.Bool
+	if len(cancelled) > 0 {
+		isCancelled = cancelled[0]
+	}
+
+	if isCancelled != nil && isCancelled.Load() {
+		return clone, fmt.Errorf("cancelled")
+	}
 	if len(scid) != 64 {
 		err = fmt.Errorf("invalid INDEX SCID: %s", scid)
 		return
@@ -1065,14 +1107,14 @@ func cloneINDEXAtCommit(height int64, scid, txid, path, endpoint string) (clone 
 
 	// If INDEX contains DocShards to be constructed
 	if strings.HasSuffix(dURL, TAG_DOC_SHARDS) {
-		err = cloneDocShards(sc, basePath, endpoint)
+		err = cloneDocShards(sc, basePath, endpoint, cancelled...)
 		if err != nil {
 			err = fmt.Errorf("%s %s", tagErr, err)
 			return
 		}
 	} else {
 		// Parse INDEX SC for valid DOCs
-		entrypoint, servePath, err = parseAndCloneINDEXForDOCs(sc, height, basePath, endpoint)
+		entrypoint, servePath, err = parseAndCloneINDEXForDOCs(sc, height, basePath, endpoint, cancelled...)
 		if err != nil {
 			// If all of the files were not cloned successfully, any residual files are removed if they did not exist already
 			err = fmt.Errorf("%s %s", tagErr, err)
@@ -1211,7 +1253,7 @@ func serveTELA(scid string, clone Cloning) (link string, err error) {
 }
 
 // ServeTELA clones and serves a TELA-INDEX-1 SC from endpoint and returns a link to the running TELA server if successful
-func ServeTELA(scid, endpoint string) (link string, err error) {
+func ServeTELA(scid, endpoint string, cancelled ...*atomic.Bool) (link string, err error) {
 	tela.Lock()
 	defer tela.Unlock()
 
@@ -1220,7 +1262,7 @@ func ServeTELA(scid, endpoint string) (link string, err error) {
 		return
 	}
 
-	clone, err := cloneINDEX(scid, dURL, tela.path.tela(), endpoint)
+	clone, err := cloneINDEX(scid, dURL, tela.path.tela(), endpoint, cancelled...)
 	if err != nil {
 		os.RemoveAll(clone.BasePath)
 		return
@@ -1231,7 +1273,7 @@ func ServeTELA(scid, endpoint string) (link string, err error) {
 
 // ServeAtCommit clones and serves a TELA-INDEX-1 SC from endpoint at commit TXID if the SC code from that commit can be decoded,
 // ensure AllowUpdates is set true prior to calling ServeAtCommit otherwise it will return error
-func ServeAtCommit(scid, txid, endpoint string) (link string, err error) {
+func ServeAtCommit(scid, txid, endpoint string, cancelled ...*atomic.Bool) (link string, err error) {
 	tela.Lock()
 	defer tela.Unlock()
 
@@ -1245,7 +1287,7 @@ func ServeAtCommit(scid, txid, endpoint string) (link string, err error) {
 		return
 	}
 
-	clone, err := cloneINDEXAtCommit(0, scid, txid, tela.path.tela(), endpoint)
+	clone, err := cloneINDEXAtCommit(0, scid, txid, tela.path.tela(), endpoint, cancelled...)
 	if err != nil {
 		os.RemoveAll(clone.BasePath)
 		return
@@ -1256,7 +1298,7 @@ func ServeAtCommit(scid, txid, endpoint string) (link string, err error) {
 
 // OpenTELALink will open content from a telaLink formatted as tela://open/<scid>/subDir/../..
 // if no server exists for that content it will try starting one using ServeTELA()
-func OpenTELALink(telaLink, endpoint string) (link string, err error) {
+func OpenTELALink(telaLink, endpoint string, cancelled ...*atomic.Bool) (link string, err error) {
 	target, args, err := ParseTELALink(telaLink)
 	if err != nil {
 		err = fmt.Errorf("could not parse tela link: %s", err)
@@ -1274,7 +1316,7 @@ func OpenTELALink(telaLink, endpoint string) (link string, err error) {
 	}
 
 	var exists bool
-	link, err = ServeTELA(args[1], endpoint)
+	link, err = ServeTELA(args[1], endpoint, cancelled...)
 	if err != nil {
 		if !strings.Contains(err.Error(), "already exists") {
 			err = fmt.Errorf("could not serve tela link: %s", err)
@@ -1821,7 +1863,7 @@ func GetRating(scid, endpoint string, height uint64) (ratings Rating_Result, err
 	}
 
 	for k, v := range vars {
-		switch k {
+		switch decodeHexString(k) {
 		case "likes":
 			if f, ok := v.(float64); ok {
 				ratings.Likes = uint64(f)


### PR DESCRIPTION
## Summary

Four stability improvements backported from Capitao117's work:

### 1. Launch Cancellation
Propagates cancellation signal through the entire TELA clone/serve chain (cloneDOC, cloneINDEX, cloneINDEXAtCommit, cloneDocShards, ServeTELA, ServeAtCommit, OpenTELALink, parseAndCloneINDEXForDOCs, parseDocShards). Each function checks the atomic bool at entry and in inner loops, enabling immediate halt of background file generation when a user cancels a TELA launch.

### 2. RPC Stability
- Global rpcSem semaphore (capacity 16) to limit concurrent RPC calls and prevent overwhelming the DERO node
- isConnectionError() helper to detect transient network failures (connection errors, EOF, broken pipe, closed, no such host)

### 3. GetRating Hex Key Fix
Fixes rating lookup failure where hex-encoded variable keys (e.g. "6c696b6573" for "likes") were compared directly against plaintext. Now calls decodeHexString(k) in the switch statement, ensuring correct attribution of likes/dislikes from blockchain data.

### 4. Preserve Azylem Fixes
- Keeps isShardFileName() function and its guard in cloneDOC (prevents individual decompression of DocShard fragments)
- Keeps shard sorting by index in parseDocShards

### Dependencies
- Updated derohe to DEROFDN/derohe community-dev branch (5cd042e8)

## Co-author
Capitao117 <kebbek88@proton.me>