### PR TITLE
fix: reject contracts which add to a TELA template

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -794,9 +794,9 @@ func GetSmartContractFuncNames(code string) (names []string) {
 	return
 }
 
-// EqualSmartContract compares if c is equal to v by parsing function lines and parts,
-// it compares all functions other than InitializePrivate/Initialize,
-// contract returned is dvm.SmartContract of v when equal
+// EqualSmartContract compares if c is equal to v by parsing function params, return values,
+// lines and parts, the lines of InitializePrivate/Initialize are not compared as they have
+// custom defined fields, contract returned is dvm.SmartContract of v when equal
 func EqualSmartContracts(c, v string) (contract dvm.SmartContract, err error) {
 	sc1, _, err := dvm.ParseSmartContract(c)
 	if err != nil {
@@ -821,8 +821,33 @@ func EqualSmartContracts(c, v string) (contract dvm.SmartContract, err error) {
 			return
 		}
 
+		// A function's params and return value are part of its definition and are
+		// compared for all functions, the Initialize funcs included
+		if len(function.Params) != len(sc2.Functions[name].Params) {
+			err = fmt.Errorf("params are not equal: %d/%d", len(function.Params), len(sc2.Functions[name].Params))
+			return
+		}
+
+		for pi, param := range function.Params {
+			if param.Name != sc2.Functions[name].Params[pi].Name || param.Type != sc2.Functions[name].Params[pi].Type {
+				err = fmt.Errorf("params are different: %s", name)
+				return
+			}
+		}
+
+		if function.ReturnValue.Name != sc2.Functions[name].ReturnValue.Name || function.ReturnValue.Type != sc2.Functions[name].ReturnValue.Type {
+			err = fmt.Errorf("return values are different: %s", name)
+			return
+		}
+
 		// Skip Initialize funcs as they have custom defined fields
 		if name != DVM_FUNC_INIT_PRIVATE && name != DVM_FUNC_INIT {
+			// Compared so that v cannot contain lines which c does not have
+			if len(function.Lines) != len(sc2.Functions[name].Lines) {
+				err = fmt.Errorf("lines are not equal: %d/%d", len(function.Lines), len(sc2.Functions[name].Lines))
+				return
+			}
+
 			for li, line := range function.Lines {
 				if _, ok := sc2.Functions[name].Lines[li]; !ok {
 					err = fmt.Errorf("line index missing: %d", li)

--- a/tela_test.go
+++ b/tela_test.go
@@ -477,6 +477,51 @@ func TestCompression(t *testing.T) {
 	}
 }
 
+// TestEqualSmartContracts covers the additions a contract can make to a TELA
+// contract without changing any of the template's own lines. These do not need
+// a simulator, EqualSmartContracts is what decides whether a SC found on chain
+// is served as TELA content so it is kept runnable on its own.
+func TestEqualSmartContracts(t *testing.T) {
+	// Rate() uses line numbers 10,15,16,20,30,40,50,60,70,100. Line 80 keeps them
+	// ascending, sits on the fall through from 70 so it is executed, and leaves
+	// every template line in place.
+	extraLine := strings.Replace(TELA_INDEX_1,
+		`70 STORE("dislikes", LOAD("dislikes")+1)`,
+		"70 STORE(\"dislikes\", LOAD(\"dislikes\")+1)\n80 STORE(\"injected\", 1)", 1)
+
+	// Definition changes which leave all of the lines untouched
+	extraParam := strings.Replace(TELA_INDEX_1,
+		"Function Rate(r Uint64) Uint64", "Function Rate(r Uint64, injected Uint64) Uint64", 1)
+	returnValue := strings.Replace(TELA_INDEX_1,
+		"Function address() String", "Function address() Uint64", 1)
+
+	for _, code := range []string{extraLine, extraParam, returnValue} {
+		assert.NotEqual(t, TELA_INDEX_1, code, "Test contract should have been modified")
+		_, _, err := dvm.ParseSmartContract(code)
+		assert.NoError(t, err, "Modified contract should be valid DVM code: %s", err)
+
+		_, err = EqualSmartContracts(TELA_INDEX_1, code)
+		assert.Error(t, err, "Contracts did not return error and should")
+
+		_, _, err = ValidINDEXVersion(code, "")
+		assert.Error(t, err, "Contract should not be a valid INDEX version")
+	}
+
+	// The unmodified contracts should still be equal to themselves
+	_, err := EqualSmartContracts(TELA_INDEX_1, TELA_INDEX_1)
+	assert.NoError(t, err, "INDEX contracts should be equal: %s", err)
+	_, err = EqualSmartContracts(TELA_DOC_1, TELA_DOC_1)
+	assert.NoError(t, err, "DOC contracts should be equal: %s", err)
+
+	// And a MOD enabled INDEX should still be equal to itself
+	for i := range Mods.mods {
+		_, modCode, err := Mods.InjectMODs(Mods.Tag(i), TELA_INDEX_1)
+		assert.NoError(t, err, "InjectMODs should not error with %s tag: %s", Mods.Tag(i), err)
+		_, err = EqualSmartContracts(modCode, modCode)
+		assert.NoError(t, err, "%s contracts should be equal: %s", Mods.Tag(i), err)
+	}
+}
+
 func TestTELA(t *testing.T) {
 	endpoint, datashards, wallets := createTestEnvironment(t)
 


### PR DESCRIPTION
## Description

`EqualSmartContracts` pins the function name set to exact equality, but within each matched function it only walks the lines of `c` and asserts each one exists identically in `v`. A contract holding every template line plus additional lines of its own therefore compares as equal. Params and return values were not read at all.

The consequence is not that a modified contract can exist, it is that the package reports one as a valid `TELA-INDEX-1` or `TELA-DOC-1`. Anything asking whether a SCID is genuine TELA content is told yes, so this reaches every host using the package.

This adds three comparisons:

- the line count, so `v` cannot carry lines that `c` does not have
- params (name, type and order), for every function
- return values (name and type), for every function

The lines of `InitializePrivate` and `Initialize` are still not compared. They hold each contract's own DOC SCIDs, dURL and headers, and legitimately differ in every contract, so comparing them would reject everything on chain.

### Compatibility

Checked against mainnet before opening this. 502 deployed TELA contracts, 80 INDEX and 422 DOC, reached by walking the DOC SCIDs of every INDEX in the on-chain index. Install heights span 4188666 to 7404083.

- all 502 still validate, unchanged, with this applied
- all 502 tampered copies are rejected by it

I also checked whether comparing `len(LineNumbers)` alongside `len(Lines)` adds anything. It does not, they never diverged across 543 functions, so it is deliberately not included.

### Tests

`TestEqualSmartContracts` is added as a top level test rather than a subtest of `TestTELA`. The existing `EqualSmartContracts` coverage sits in `TestTELA/Parse`, which needs a running simulator and the `Install` subtest to complete first, so it does not run under a plain `go test`. Since this function decides whether a SC found on chain is served as TELA content, the coverage is kept runnable on its own, next to `TestIsShardFileName` and `TestCompression`. Happy to move it in with the others if you would prefer that.

Reverting `parse.go` while keeping the test produces 6 assertion failures.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
