### PR TITLE
fix: return the injected smart contract from InjectMODs

### DIFF
--- a/mods.go
+++ b/mods.go
@@ -497,7 +497,8 @@ func (m *MODs) injectMOD(mod, code string) (modSC dvm.SmartContract, modCode str
 	return
 }
 
-// InjectMODs parses the modTag ensuring all tags are valid before injecting the TELA-MOD code for the given MODs in the modTag
+// InjectMODs parses the modTag ensuring all tags are valid before injecting the TELA-MOD code for the given MODs in the modTag,
+// when no error is returned the modSC will reflect the modCode. If an empty modTag is passed the code is returned unchanged with its parsed SC
 func (m *MODs) InjectMODs(modTag, code string) (modSC dvm.SmartContract, modCode string, err error) {
 	tags, err := m.TagsAreValid(modTag)
 	if err != nil {
@@ -505,9 +506,19 @@ func (m *MODs) InjectMODs(modTag, code string) (modSC dvm.SmartContract, modCode
 		return
 	}
 
-	modCode = code // tags could be nil otherwise start injecting mods
+	modCode = code
+	if len(tags) < 1 {
+		// No MODs to inject, parse the code so modSC always reflects modCode
+		modSC, _, err = dvm.ParseSmartContract(modCode)
+		if err != nil {
+			err = fmt.Errorf("could not parse MOD base code: %s", err)
+		}
+
+		return
+	}
+
 	for _, mod := range tags {
-		_, modCode, err = m.injectMOD(mod, modCode)
+		modSC, modCode, err = m.injectMOD(mod, modCode)
 		if err != nil {
 			return
 		}

--- a/tela_test.go
+++ b/tela_test.go
@@ -2344,6 +2344,28 @@ func TestTELA(t *testing.T) {
 		assert.NoError(t, err, "injectMOD should not error with valid code and %s tag", Mods.Tag(4))
 		_, _, err = Mods.InjectMODs(Mods.Tag(5), TELA_INDEX_1)
 		assert.NoError(t, err, "injectMOD should not error with valid code and %s tag", Mods.Tag(5))
+		// InjectMODs should always return a modSC which reflects its modCode
+		modSC, modCode, err := Mods.InjectMODs("", TELA_INDEX_1)
+		assert.NoError(t, err, "InjectMODs should not error with empty modTag")
+		assert.Equal(t, TELA_INDEX_1, modCode, "InjectMODs should not change code with empty modTag")
+		parsedSC, _, err := dvm.ParseSmartContract(modCode)
+		assert.NoError(t, err, "Parsing modCode should not error with empty modTag")
+		assert.Equal(t, parsedSC.Functions, modSC.Functions, "InjectMODs should return the SC of its code with empty modTag")
+		for i := range Mods.mods {
+			modSC, modCode, err = Mods.InjectMODs(Mods.Tag(i), TELA_INDEX_1)
+			assert.NoError(t, err, "InjectMODs should not error with valid code and %s tag", Mods.Tag(i))
+			parsedSC, _, err = dvm.ParseSmartContract(modCode)
+			assert.NoError(t, err, "Parsing modCode should not error with %s tag", Mods.Tag(i))
+			assert.Equal(t, parsedSC.Functions, modSC.Functions, "InjectMODs should return the SC of its code with %s tag", Mods.Tag(i))
+		}
+		// Multi MOD tags inject more then once, the modSC should reflect all of the MODs injected
+		for _, multiTag := range []string{"vsoo,txdwd", "txdwd,txto", "vspubow,txdwa,txto"} {
+			modSC, modCode, err = Mods.InjectMODs(multiTag, TELA_INDEX_1)
+			assert.NoError(t, err, "InjectMODs should not error with valid code and %s tags", multiTag)
+			parsedSC, _, err = dvm.ParseSmartContract(modCode)
+			assert.NoError(t, err, "Parsing modCode should not error with %s tags", multiTag)
+			assert.Equal(t, parsedSC.Functions, modSC.Functions, "InjectMODs should return the SC of its code with %s tags", multiTag)
+		}
 
 		// Test Add
 		err = Mods.Add(


### PR DESCRIPTION
## Description

The named return `modSC` is never assigned on any path, so callers always receive a zero value `dvm.SmartContract` alongside a nil error. The loop discards the contract returned by `injectMOD`, and when `modTag` is empty the loop does not run at all.

`InjectMODs("vsoo", TELA_INDEX_1)` returns a contract with 0 functions, where the unexported `injectMOD("vsoo", ...)` returns 7.

This assigns `modSC` from `injectMOD`, and parses the code when there are no tags, so the returned `modSC` reflects the returned `modCode` whenever no error is returned.

The only caller that uses the returned contract is `createContractVersions` in `parse.go`. That path is currently unreachable, it sits behind a version check that is false for the shipped version list, but it would assign an empty contract to `sc` once a version is added.

### Behaviour note

`InjectMODs` with an empty `modTag` and code that does not parse now returns an error where it previously returned nil. No in-tree caller can reach this: `parse.go` only passes the embedded `TELA_INDEX_1` and `TELA_DOC_1` constants, and both `tela.go` call sites are guarded by `h.Mods != ""`. An external caller could.

Everything else is unchanged. Across 36 combinations of code and tag inputs the returned `modCode` is byte identical before and after, as is the output of `ValidINDEXVersion` and `ValidDOCVersion`.

### Tests

Assertions added alongside the existing `InjectMODs` coverage in `TestTELA/MODs`, covering the empty `modTag`, each single tag, and multi tag combinations. Reverting `mods.go` while keeping the tests produces 12 assertion failures.

That subtest needs a simulator and runs after `Install`, so it does not run under a plain `go test`. I kept it there because that is where the sibling `InjectMODs` assertions already live, but happy to move it out.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
