### PR TITLE
fix: bind a checkout's TXID to the SCID it is requested against

### DIFF
--- a/commit_test.go
+++ b/commit_test.go
@@ -1,0 +1,107 @@
+package tela
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/deroproject/derohe/cryptography/crypto"
+	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
+	"github.com/stretchr/testify/assert"
+)
+
+// scidHex returns a deterministic 64 character SCID for tests
+func scidHex(b byte) string {
+	var h crypto.Hash
+	for i := range h {
+		h[i] = b
+	}
+
+	return hex.EncodeToString(h[:])
+}
+
+// scTX builds a SC transaction carrying args
+func scTX(args rpc.Arguments) *transaction.Transaction {
+	var tx transaction.Transaction
+	tx.Version = 1
+	tx.TransactionType = transaction.SC_TX
+	tx.SCDATA = args
+
+	return &tx
+}
+
+// TestCommitSCID covers which contract a checkout TXID actually applies to.
+//
+// cloneINDEXAtCommit reads the dURL from the SCID but rebuilds the code from the
+// TXID. Without comparing the two, asking for one contract's history with
+// another contract's TXID serves the second contract's files under the first
+// contract's dURL.
+func TestCommitSCID(t *testing.T) {
+	scidA := scidHex(0xaa)
+	scidB := scidHex(0xbb)
+
+	var targetB crypto.Hash
+	raw, err := hex.DecodeString(scidB)
+	assert.NoError(t, err, "Test SCID should decode")
+	copy(targetB[:], raw)
+
+	t.Run("Install", func(t *testing.T) {
+		// A contract's SCID is the hash of the transaction that installed it
+		tx := scTX(rpc.Arguments{
+			{Name: rpc.SCACTION, DataType: rpc.DataUint64, Value: uint64(rpc.SC_INSTALL)},
+			{Name: rpc.SCCODE, DataType: rpc.DataString, Value: "Function Initialize() Uint64\n10 RETURN 0\nEnd Function"},
+		})
+
+		scid, err := commitSCID(tx, scidA)
+		assert.NoError(t, err, "Install should be a valid commit")
+		assert.Equal(t, scidA, scid, "Install commit should apply to its own TXID")
+	})
+
+	t.Run("Call", func(t *testing.T) {
+		tx := scTX(rpc.Arguments{
+			{Name: rpc.SCACTION, DataType: rpc.DataUint64, Value: uint64(rpc.SC_CALL)},
+			{Name: rpc.SCID, DataType: rpc.DataHash, Value: targetB},
+			{Name: "entrypoint", DataType: rpc.DataString, Value: "UpdateCode"},
+		})
+
+		// Called with A's TXID, but the transaction names B
+		scid, err := commitSCID(tx, scidA)
+		assert.NoError(t, err, "Call should be a valid commit")
+		assert.Equal(t, scidB, scid, "Call commit should apply to the SCID it names, not the TXID")
+	})
+
+	t.Run("Not a commit", func(t *testing.T) {
+		var normal transaction.Transaction
+		normal.Version = 1
+		normal.TransactionType = transaction.NORMAL
+		_, err := commitSCID(&normal, scidA)
+		assert.Error(t, err, "Non SC transaction should not be a commit")
+
+		_, err = commitSCID(scTX(rpc.Arguments{
+			{Name: "entrypoint", DataType: rpc.DataString, Value: "UpdateCode"},
+		}), scidA)
+		assert.Error(t, err, "SC transaction with no action should not be a commit")
+
+		_, err = commitSCID(scTX(rpc.Arguments{
+			{Name: rpc.SCACTION, DataType: rpc.DataUint64, Value: uint64(rpc.SC_CALL)},
+		}), scidA)
+		assert.Error(t, err, "Call naming no contract should not be a commit")
+	})
+}
+
+// TestCommitMatchesSCID covers the binding cloneINDEXAtCommit applies before it
+// rebuilds a contract's code from a TXID.
+func TestCommitMatchesSCID(t *testing.T) {
+	scidA := scidHex(0xaa)
+
+	t.Run("Malformed", func(t *testing.T) {
+		err := commitMatchesSCID("nothex", scidA, scidA)
+		assert.Error(t, err, "Undecodable TXID data should be rejected")
+
+		err = commitMatchesSCID("aabbcc", scidA, scidA)
+		assert.Error(t, err, "Undeserializable TXID data should be rejected")
+
+		err = commitMatchesSCID("", scidA, scidA)
+		assert.Error(t, err, "Empty TXID data should be rejected")
+	})
+}

--- a/tela.go
+++ b/tela.go
@@ -27,6 +27,7 @@ import (
 	"github.com/deroproject/derohe/dvm"
 	"github.com/deroproject/derohe/globals"
 	"github.com/deroproject/derohe/rpc"
+	"github.com/deroproject/derohe/transaction"
 	"github.com/deroproject/derohe/walletapi"
 	"github.com/gorilla/websocket"
 
@@ -450,6 +451,61 @@ func getTXID(txid, endpoint string) (txidAsHex string, height int64, err error) 
 	height = result.Txs[0].Block_Height
 
 	return
+}
+
+// commitSCID returns the SCID a TELA commit transaction applies to.
+//
+// A commit is one of two things. An install, where the contract's SCID is the
+// hash of the transaction that created it, so the answer is the TXID itself. Or
+// a SC_CALL, which names the contract it invokes in SC_ID. Anything else is not
+// a commit.
+func commitSCID(tx *transaction.Transaction, txid string) (scid string, err error) {
+	if tx.TransactionType != transaction.SC_TX {
+		return "", fmt.Errorf("TXID %s is not a smart contract transaction", txid)
+	}
+
+	if !tx.SCDATA.Has(rpc.SCACTION, rpc.DataUint64) {
+		return "", fmt.Errorf("TXID %s has no SC action", txid)
+	}
+
+	if rpc.SC_ACTION(tx.SCDATA.Value(rpc.SCACTION, rpc.DataUint64).(uint64)) == rpc.SC_INSTALL {
+		return txid, nil
+	}
+
+	if !tx.SCDATA.Has(rpc.SCID, rpc.DataHash) {
+		return "", fmt.Errorf("TXID %s does not name a contract", txid)
+	}
+
+	target := tx.SCDATA.Value(rpc.SCID, rpc.DataHash).(crypto.Hash)
+
+	return hex.EncodeToString(target[:]), nil
+}
+
+// commitMatchesSCID checks that a transaction was a commit against scid.
+//
+// txidAsHex is the raw transaction getTXID has already fetched, so this adds no
+// further calls to the endpoint.
+func commitMatchesSCID(txidAsHex, scid, txid string) (err error) {
+	raw, err := hex.DecodeString(txidAsHex)
+	if err != nil {
+		return fmt.Errorf("could not decode TXID data: %s", err)
+	}
+
+	var tx transaction.Transaction
+	if err = tx.Deserialize(raw); err != nil {
+		return fmt.Errorf("could not deserialize TXID data: %s", err)
+	}
+
+	target, err := commitSCID(&tx, txid)
+	if err != nil {
+		return err
+	}
+
+	if !strings.EqualFold(target, scid) {
+		return fmt.Errorf("TXID %s is a commit against %s, not %s", txid, target, scid)
+	}
+
+	return nil
 }
 
 // Get the current state of all string keys in a smart contract
@@ -1077,6 +1133,15 @@ func cloneINDEXAtCommit(height int64, scid, txid, path, endpoint string, cancell
 		txidAsHex, commitHeight, errr := getTXID(txid, endpoint)
 		if errr != nil {
 			err = fmt.Errorf("%s could not get TXID: %s", tagErr, errr)
+			return
+		}
+
+		// The code below comes from the TXID while the dURL above came from the
+		// SCID. Without this the two are never compared, and a checkout of one
+		// contract's history with another contract's TXID serves the second
+		// contract's files under the first contract's dURL.
+		if err = commitMatchesSCID(txidAsHex, scid, txid); err != nil {
+			err = fmt.Errorf("%s %s", tagErr, err)
 			return
 		}
 


### PR DESCRIPTION
## Description

`cloneINDEXAtCommit` reads the dURL from the supplied SCID but rebuilds the contract code from the supplied TXID, and nothing compares the two.

- dURL comes from the SCID, `tela.go:1059`
- code comes from the TXID, `tela.go:1085` via `getTXID` and `extractCodeFromTXID`
- `ValidINDEXVersion` then passes, because the other contract is itself a valid TELA-INDEX

So a checkout of one contract's history with another contract's TXID clones the second contract's files into a directory named after the first contract's dURL, and `ServeAtCommit` serves them under that name.

Reproduced against mainnet, using `deaddrop-library.tela` as the SCID and `telatomicswaps.tela` as the TXID:

```
CloneAtCommit(f794891d…, 85010fe9…)  ->  no error

  deaddrop-library.tela/index.html     17130 bytes
  deaddrop-library.tela/buttons.js     15613 bytes
  deaddrop-library.tela/derocalls.js   17597 bytes
  … 13 files, all telatomicswaps
```

### The fix

A commit is one of two things. An install, where the contract's SCID is the hash of the transaction that created it, so the TXID is the answer. Or a `SC_CALL`, which names its target in `SC_ID`. `commitSCID` reads whichever applies and `commitMatchesSCID` compares it to the requested SCID.

It deserializes the transaction `getTXID` has already fetched, so no further calls to the endpoint are added.

Only the first-INDEX branch is affected. The `height > 0` branch reads code through `getContractCodeAtHeight(height, scid, endpoint)` and was already bound to the SCID.

### Behaviour note

Legitimate checkouts are unchanged, verified against mainnet: an install commit, an `UpdateCode` commit on the same contract, and a second contract's install commit all still clone. Only the mismatched pair is rejected, with the message naming the contract the TXID actually commits to.

### Tests

`TestCommitSCID` covers install, call, a non-SC transaction, an SC transaction with no action, and a call naming no contract. `TestCommitMatchesSCID` covers undecodable, undeserializable and empty transaction data.

These construct transactions in memory and need no simulator, so they run under a plain `go test`. Reverting `commitSCID`'s `SC_ID` read fails `TestCommitSCID/Call`; removing the check from `cloneINDEXAtCommit` makes the mainnet reproduction succeed again.

### Note on the existing suite

`TestTELA` did not run to completion in my environment, and it fails the same way on a clean `dev` with my branch stashed, so it is unrelated to this change.

Correcting what I first wrote here about the cause. I said wallet 0 was unregistered, because `walletSeeds[0]` is `2af66309…` while the simulator reports its wallet 0 as `171eeaa8…`. That was wrong. Both are simulator wallets at different indices in `cmd/simulator/wallets.go`, `171eeaa8…` at line 42 and `2af66309…` at line 55, and both are registered. Installs on `wallets[0]` succeed.

What I see instead, with a simulator built from the `derohe` revision this repo pins and started with `--testnet`: `Install` fails intermittently on statement and nonce verification under fast automine, and `Exported` fails on an address prefix, expecting `deto1…` and getting `dero1…`, which looks like the network globals being changed partway through the run. `Install`, `Exported` and `ServeTELA` fail the same way on a clean `dev`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).

