### PR TITLE
fix(parse): match DOC keys exactly when parsing an INDEX

### DIFF
--- a/indexdoc_test.go
+++ b/indexdoc_test.go
@@ -1,0 +1,77 @@
+package tela
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/deroproject/derohe/dvm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseINDEXForDOCs_NoPanic covers the reader crash (a header value whose
+// token contains "DOC drove an out-of-range read). GetINDEXInfo reaches this
+// with no recover, so a malicious INDEX crashed any client that opened it.
+func TestParseINDEXForDOCs_NoPanic(t *testing.T) {
+	cases := map[string]string{
+		// An INDEX literally named "DOCS" - a completely ordinary name. The
+		// value token "DOCS" lands last, so the old code read two tokens past it.
+		"header value named DOCS": `Function InitializePrivate() Uint64
+10 STORE("var_header_name", "DOCS")
+20 STORE("DOC1", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+1000 RETURN 0
+End Function`,
+		"header value starting DOC": `Function InitializePrivate() Uint64
+10 STORE("var_header_description", "DOCument viewer")
+20 STORE("DOC1", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+1000 RETURN 0
+End Function`,
+	}
+	for name, code := range cases {
+		t.Run(name, func(t *testing.T) {
+			sc, _, err := dvm.ParseSmartContract(code)
+			if err != nil {
+				t.Skipf("fixture did not parse: %v", err)
+			}
+			// Must not panic, and must still find the one real DOC.
+			got := parseINDEXForDOCs(sc)
+			assert.Equal(t, 1, len(got), "should find exactly the one real DOC")
+		})
+	}
+}
+
+// TestParseINDEXForDOCs_NumericOrder covers the lexicographic sort: DOC10..DOC13
+// sorted before DOC2, mis-ordering every INDEX with 10 or more documents.
+func TestParseINDEXForDOCs_NumericOrder(t *testing.T) {
+	code := "Function InitializePrivate() Uint64\n"
+	for i := 1; i <= 13; i++ {
+		// scid encodes the intended index so order is checkable
+		scid := fmt.Sprintf("%064d", i)
+		code += fmt.Sprintf("%d STORE(\"DOC%d\", \"%s\")\n", i*10, i, scid)
+	}
+	code += "1000 RETURN 0\nEnd Function"
+
+	sc, _, err := dvm.ParseSmartContract(code)
+	assert.NoError(t, err)
+
+	got := parseINDEXForDOCs(sc)
+	assert.Equal(t, 13, len(got))
+	for i, scid := range got {
+		want := fmt.Sprintf("%064d", i+1) // position i must hold DOC(i+1)
+		assert.Equal(t, want, scid, "DOC at position %d out of order", i)
+	}
+}
+
+// TestDocKeyNumber pins the precise key match that replaces the substring test.
+func TestDocKeyNumber(t *testing.T) {
+	yes := map[string]int{`"DOC1"`: 1, `"DOC10"`: 10, `"DOC999"`: 999, "DOC2": 2}
+	for tok, n := range yes {
+		got, ok := docKeyNumber(tok)
+		assert.True(t, ok, "%q should be a DOC key", tok)
+		assert.Equal(t, n, got)
+	}
+	no := []string{`"DOCS"`, `"DOC"`, `"DOCument"`, `"var_header_name"`, `"DOC1a"`, `""`, `"scid"`}
+	for _, tok := range no {
+		_, ok := docKeyNumber(tok)
+		assert.False(t, ok, "%q should NOT be a DOC key", tok)
+	}
+}

--- a/parse.go
+++ b/parse.go
@@ -135,30 +135,56 @@ func ParseINDEXForDOCs(code string) (scids []string, err error) {
 }
 
 // Parse an INDEX dvm.SmartContract for its DOC SCIDs
+// docKeyNumber reports whether token is a TELA DOC key - the string "DOC"
+// followed by digits, e.g. `"DOC12"` - and returns its number.
+//
+// It replaces a substring test on `"DOC`, which also matched any header value
+// containing that text (an INDEX named "DOCS" is enough), and, when such a value
+// fell in the last two tokens of its line, drove an out-of-range read two tokens
+// on. Matching the exact key shape removes both the false positive and the panic.
+func docKeyNumber(token string) (n int, ok bool) {
+	digits := strings.TrimPrefix(strings.Trim(token, `"`), "DOC")
+	if digits == "" || digits == strings.Trim(token, `"`) {
+		return 0, false
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
 func parseINDEXForDOCs(sc dvm.SmartContract) (scids []string) {
-	var docKeys []string
-	docMap := map[string]string{}
+	type docEntry struct {
+		num  int
+		scid string
+	}
+	var docs []docEntry
 	for name, function := range sc.Functions {
 		// Find initialize function and parse lines
-		if name == DVM_FUNC_INIT_PRIVATE {
-			for _, line := range function.Lines {
-				// Parse the contents of the line
-				for i, parts := range line {
-					if strings.Contains(parts, string(HEADER_DOCUMENT)) {
-						// Line STORE is a DOC#, find its scid
-						scid := strings.Trim(line[i+2], `"`)
-						docKeys = append(docKeys, parts)
-						docMap[parts] = scid
-					}
+		if name != DVM_FUNC_INIT_PRIVATE {
+			continue
+		}
+		for _, line := range function.Lines {
+			// Parse the contents of the line
+			for i, parts := range line {
+				num, ok := docKeyNumber(parts)
+				// The scid is two tokens on: DOC# , "scid". Skip if the line
+				// ends before that - a header value that looks like a DOC key
+				// no longer reads past the line.
+				if !ok || i+2 >= len(line) {
+					continue
 				}
+				docs = append(docs, docEntry{num: num, scid: strings.Trim(line[i+2], `"`)})
 			}
 		}
 	}
 
-	// Sort DOC scids by DOC#
-	sort.Strings(docKeys)
-	for _, v := range docKeys {
-		scids = append(scids, docMap[v])
+	// Order by DOC number, not lexicographically, so DOC10 follows DOC9 rather
+	// than DOC1.
+	sort.Slice(docs, func(a, b int) bool { return docs[a].num < docs[b].num })
+	for _, d := range docs {
+		scids = append(scids, d.scid)
 	}
 
 	return
@@ -181,7 +207,10 @@ func parseAndCloneINDEXForDOCs(sc dvm.SmartContract, height int64, basePath, end
 				}
 				// Parse the contents of the line
 				for i, parts := range line {
-					if strings.Contains(parts, string(HEADER_DOCUMENT)) {
+					// The scid is two tokens on: DOC# , "scid". A precise key
+					// match with a bounds guard keeps a header value that merely
+					// contains "DOC from reading past the end of the line.
+					if _, ok := docKeyNumber(parts); ok && i+2 < len(line) {
 						// Line STORE is a DOC#, find scid and get its document data
 						scid := strings.Trim(line[i+2], `"`)
 						isDOC1 := Header(parts) == HEADER_DOCUMENT.Number(1)


### PR DESCRIPTION
## Description

`parseINDEXForDOCs` and `parseAndCloneINDEXForDOCs` find a contract's documents by testing whether each token contains the substring `"DOC`, then reading the scid two tokens on. Two defects follow.

**A header value is enough to match.** `HEADER_DOCUMENT` is the unterminated `` `"DOC` ``, so any token containing that text matches, not only a DOC key. An INDEX named `DOCS` produces the token `"DOCS"`, which sits in the last two tokens of its line, so the read two tokens on goes out of range:

```
STORE("var_header_name", "DOCS")   ->  tokens: STORE ( "var_header_name" , "DOCS" )
                                                                            ^ i=4
                                       line[i+2] = line[6], len(line) = 6

panic: runtime error: index out of range [6] with length 6
        tela/parse.go:149  parseINDEXForDOCs
```

`GetINDEXInfo` reaches this with no recover, so opening such an INDEX panics the reader rather than returning an error.

**Ten or more documents are returned out of order.** The keys are ordered with `sort.Strings`, so `DOC10` through `DOC13` sort before `DOC2`. On mainnet today that is 30 of the 102 reachable INDEXes, across 11 distinct dURLs, `explorer.tela` and `1.2.0.ghost.trading` among them.

### The fix

`docKeyNumber` matches the exact key shape, the string `DOC` followed by digits, and returns the number. Both call sites use it, and both guard the read two tokens on, so a value that merely looks like a key can no longer read past the end of its line. The reader orders by the returned number rather than lexicographically.

### Behaviour note

Swept across all 102 mainnet INDEXes, comparing before and after. The DOC set is unchanged for every one of them, no document added and none dropped, and the order changes for exactly the 30 holding ten or more documents. That correspondence is exact, which is the useful check here: the change touches the INDEXes it should and no others.

Worth noting for scope, since it is easy to assume otherwise: this does not affect sharded file reconstruction. `parseDocShards` re-reads the shard number from each DOC's file name and sorts on that independently, and `DOC1` sorts first lexicographically anyway, so the `i == 0` branch that picks the output name was always correct. The ordering reaches consumers of `ParseINDEXForDOCs` and `INDEX.DOCs`.

### Tests

`TestParseINDEXForDOCs_NoPanic` covers a header value named `DOCS` and one beginning `DOCument`, asserting the real DOC is still found. `TestParseINDEXForDOCs_NumericOrder` builds an INDEX of 13 documents whose scids encode their intended position. `TestDocKeyNumber` pins the match itself, accepting `DOC1`, `DOC10`, `DOC999` and rejecting `DOCS`, `DOC`, `DOCument`, `DOC1a` and ordinary header keys.

All run under a plain `go test` with no simulator. Reverting either half fails its own test: the sort reverts to mis-ordered, and the match reverts to the out-of-range panic.

### Note on the existing suite

`TestTELA` does not run to completion in my environment, and `Install`, `Exported` and `ServeTELA` fail the same way on a clean `dev`, so they are unrelated to this change. With a simulator built from the `derohe` revision this repo pins and started with `--testnet`, `Install` fails intermittently on statement and nonce verification under fast automine, and `Exported` fails on an address prefix, expecting `deto1…` and getting `dero1…`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
