### PR TITLE
fix(parse): escape quotes and backslashes in header values

### DIFF
--- a/escape_test.go
+++ b/escape_test.go
@@ -1,0 +1,93 @@
+package tela
+
+import (
+	"go/parser"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/deroproject/derohe/dvm"
+	"github.com/stretchr/testify/assert"
+)
+
+// dvmEvalString evaluates a quoted string literal exactly as the DVM does at
+// runtime: it is parsed as an expression and unquoted (dvm.go, *ast.BasicLit
+// token.STRING -> strconv.Unquote). A literal that fails here panics the DVM.
+func dvmEvalString(literal string) (string, error) {
+	if _, err := parser.ParseExpr(literal); err != nil {
+		return "", err
+	}
+	return strconv.Unquote(literal)
+}
+
+// TestFormatValueRoundTrips is the core of the fix: every header value, however
+// hostile, must survive formatValue -> on-chain literal -> DVM evaluation
+// unchanged. The trailing backslash is the O14 case that escaped its own
+// closing quote under the old fmt.Sprintf("%q"-less) formatting.
+func TestFormatValueRoundTrips(t *testing.T) {
+	cases := []string{
+		"index.html",
+		"A normal description",
+		`My App\`,            // O14 - trailing backslash
+		`ends with a quote"`, // embedded quote
+		`both \ and "`,
+		"line1\nline2\ttabbed", // control chars
+		"café ☕ 日本語",           // non-ASCII
+		"",                     // empty
+		`STORE("x","y")`,       // looks like code
+	}
+	for _, in := range cases {
+		lit := formatValue(in)
+		got, err := dvmEvalString(lit)
+		assert.NoError(t, err, "value %q produced a literal the DVM would panic on: %s", in, lit)
+		assert.Equal(t, in, got, "value %q did not round-trip (literal %s)", in, lit)
+	}
+}
+
+// TestFormatValueASCIIUnchanged pins that ordinary values are byte-identical to
+// the previous formatting, so nothing about a normal contract's code changes.
+func TestFormatValueASCIIUnchanged(t *testing.T) {
+	for _, in := range []string{"index.html", "My App", "telatomicswaps.tela", "2d7b1452f42652c4"} {
+		assert.Equal(t, `"`+in+`"`, formatValue(in), "ordinary value %q must format as before", in)
+	}
+}
+
+// TestParseHeadersProducesEvaluableCode proves a full INDEX built with hostile
+// header values emits literals the DVM can evaluate.
+//
+// Parsing is not the test. The old formatting produced code that parsed and
+// failed later, at evaluation, where the DVM unquotes each string literal and
+// panics if it is malformed - so this asserts on the literals themselves.
+func TestParseHeadersProducesEvaluableCode(t *testing.T) {
+	idx := &INDEX{
+		DURL:    "test.tela",
+		DOCs:    []string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		Headers: Headers{NameHdr: `My App\`, DescrHdr: `has "quotes" and \ slash`},
+	}
+	code, err := ParseHeaders(TELA_INDEX_1, idx)
+	assert.NoError(t, err)
+
+	sc, _, err := dvm.ParseSmartContract(code)
+	assert.NoError(t, err, "generated contract did not parse")
+
+	// Every string literal the contract stores must survive the DVM's own
+	// evaluation. Under the old formatting the nameHdr and descrHdr literals
+	// fail here with "invalid syntax", which is a panic at runtime.
+	checked := 0
+	for name, function := range sc.Functions {
+		if name != DVM_FUNC_INIT_PRIVATE {
+			continue
+		}
+		for number, line := range function.Lines {
+			for _, token := range line {
+				if !strings.HasPrefix(token, `"`) {
+					continue
+				}
+				checked++
+				_, uerr := strconv.Unquote(token)
+				assert.NoError(t, uerr, "line %v literal %s would panic the DVM", number, token)
+			}
+		}
+	}
+	assert.NotZero(t, checked, "no string literals were checked")
+}

--- a/parse.go
+++ b/parse.go
@@ -54,12 +54,17 @@ func formatValue(value interface{}) string {
 	switch v := value.(type) {
 	case uint64:
 		return fmt.Sprintf("%d", v)
-	case string:
-		return fmt.Sprintf(`"%s"`, v)
 	case int:
 		return fmt.Sprintf("%d", uint64(v))
+	case string:
+		// strconv.Quote, not `"%s"`: a header value containing a quote,
+		// backslash or newline otherwise produces a broken string literal - a
+		// trailing "\" escapes the closing quote, and the DVM evaluates literals
+		// with strconv.Unquote (dvm.go), which panics on the malformed result.
+		// Quote is the exact inverse of that Unquote, so any value round-trips.
+		return strconv.Quote(v)
 	default:
-		return fmt.Sprintf(`"%s"`, strings.ReplaceAll(fmt.Sprintf("%v", v), "\n", " "))
+		return strconv.Quote(fmt.Sprintf("%v", v))
 	}
 }
 


### PR DESCRIPTION
## Description

`formatValue` wraps a string as `` `"%s"` `` with no escaping, so a header value holding a quote, a backslash or a newline produces a malformed string literal. A trailing backslash escapes the closing quote outright:

```
NameHdr = My App\        ->  30 STORE("nameHdr", "My App\")
                                                          ^ the closing quote is escaped
```

The DVM evaluates string literals with `strconv.Unquote` and panics when it fails, `dvm/dvm.go:954`:

```go
case token.STRING:
        unquoted, err := strconv.Unquote(exp.Value)
        if err != nil {
                panic(err)
        }
```

So the generated contract parses and fails later, at evaluation. A name like `My App\` yields a contract that cannot execute.

### The fix

`strconv.Quote` is the exact inverse of the `strconv.Unquote` the DVM uses, so any value round-trips. The `default` case is changed with it: it previously replaced newlines with spaces, which was a partial attempt at the same thing, keeping the literal on one line. `Quote` does that completely and also handles carriage returns, quotes and backslashes, which matters because DVM code is line structured.

### Behaviour note

Ordinary values are unaffected, byte for byte. Checked against mainnet by running every distinct header value currently in use through `ParseHeaders` and diffing the generated code, 1,056 values in total: every plain-ASCII one is identical, and the printable non-ASCII ones are too. The values that do change all contain quotes and newlines, and under the old formatting they produced broken literals anyway.

No validation regression. `ValidINDEXVersion` over every mainnet INDEX is unchanged, 81 validating and 21 rejecting, the same set before and after. `EqualSmartContracts` does not compare the `InitializePrivate` body, where headers live, so this was expected, but it seemed worth measuring rather than assuming.

### Tests

`TestFormatValueRoundTrips` puts each hostile value through `formatValue` and then evaluates the result the way the DVM does, `go/parser` followed by `strconv.Unquote`, covering a trailing backslash, embedded quotes, newlines, tabs, non-ASCII, empty, and a value that looks like code. `TestFormatValueASCIIUnchanged` pins that ordinary values format exactly as before. `TestParseHeadersProducesEvaluableCode` builds a full INDEX with hostile headers and asserts every string literal in it is evaluable, since parsing alone does not catch this.

All run under a plain `go test` with no simulator. Reverting to the old formatting fails the round-trip test, and fails `TestParseHeadersProducesEvaluableCode` with `literal " and \ slash" would panic the DVM`.

### Note on the existing suite

`TestTELA` does not run to completion in my environment, and `Exported` and `ServeTELA` fail the same way on a clean `dev`, so they are unrelated to this change. With a simulator built from the `derohe` revision this repo pins and started with `--testnet`, `Install` also fails intermittently on statement and nonce verification under fast automine, and `Exported` fails on an address prefix, expecting `deto1…` and getting `dero1…`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
