### PR TITLE
fix: contain the clone/serve path against contract-controlled names

### DIFF
--- a/safejoin_test.go
+++ b/safejoin_test.go
@@ -1,0 +1,64 @@
+package tela
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSafeJoin covers the containment guard on the clone/serve path. Every input
+// here is a value a smart contract controls - a dURL, a subDir, or a header file
+// name - and each reaches an os.Create/os.WriteFile.
+func TestSafeJoin(t *testing.T) {
+	base := filepath.Join("/tmp", "datashards", "clone")
+
+	t.Run("Escapes are rejected", func(t *testing.T) {
+		bad := []string{
+			"../../../../../../tmp/pwned", // the reproduced dURL exploit
+			"../evil.desktop",             // one level up, parent exists
+			"..",
+			"a/../../b",
+			"sub/../../../etc/x",
+		}
+		for _, e := range bad {
+			_, err := safeJoin(base, e)
+			assert.Error(t, err, "must reject %q", e)
+		}
+	})
+
+	t.Run("Legitimate paths are allowed", func(t *testing.T) {
+		good := []string{
+			"villager.tela",
+			"villager/rive.js-2.35.3.shards", // a real mainnet dURL with a separator
+			"index.html",
+			"sub1/sub2/file.js",
+			"a/../b", // stays within base
+			"",
+			".",
+		}
+		for _, e := range good {
+			got, err := safeJoin(base, e)
+			assert.NoError(t, err, "must allow %q", e)
+			// and the result must actually be within base
+			assert.True(t, got == base || strings.HasPrefix(got, base+string(filepath.Separator)),
+				"%q resolved outside base: %s", e, got)
+		}
+	})
+
+	t.Run("Absolute element is contained, not honored", func(t *testing.T) {
+		got, err := safeJoin(base, "/etc/passwd")
+		assert.NoError(t, err)
+		assert.True(t, strings.HasPrefix(got, base+string(filepath.Separator)), "absolute path escaped: %s", got)
+	})
+}
+
+// TestConstructFromShardsContainment pins the specific site O19 reopened on:
+// the .shards clone path, which the first containment sweep missed.
+func TestConstructFromShardsContainment(t *testing.T) {
+	base := t.TempDir()
+	err := ConstructFromShards([][]byte{[]byte("payload")}, "../escaped.desktop", base, "")
+	assert.Error(t, err, "ConstructFromShards must reject a traversal file name")
+	assert.NoFileExists(t, filepath.Join(filepath.Dir(base), "escaped.desktop"))
+}

--- a/tela.go
+++ b/tela.go
@@ -235,6 +235,29 @@ func (s ds) clone() string {
 	return filepath.Join(s.main, "clone")
 }
 
+// safeJoin joins elem onto base and fails if the result would fall outside base.
+//
+// The clone and serve paths are built from values a smart contract controls -
+// its dURL, its subDir, and the file names in its headers - and every one of
+// them reaches an os.Create or os.WriteFile. Without this a contract whose dURL
+// is "../../../foo" (or whose header names a "../foo" file) writes outside the
+// datashards directory entirely. filepath.Join cleans "." and ".." but does not
+// stop the result from escaping base, so the check is explicit.
+func safeJoin(base, elem string) (joined string, err error) {
+	joined = filepath.Join(base, elem)
+
+	// Both paths share base, so they have the same relativity and Rel is valid.
+	rel, err := filepath.Rel(base, joined)
+	if err != nil {
+		return "", fmt.Errorf("invalid path element %q: %s", elem, err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path element %q escapes the clone directory", elem)
+	}
+
+	return joined, nil
+}
+
 // Find if port is within valid range
 func isValidPort(port int) bool {
 	if port < DEFAULT_MIN_PORT || port > DEFAULT_MAX_PORT-tela.max {
@@ -757,7 +780,9 @@ func cloneDOC(scid, docNum, path, endpoint string, cancelled ...*atomic.Bool) (c
 		// Split all subDir to create path
 		split := strings.Split(subDir, "/")
 		for _, s := range split {
-			path = filepath.Join(path, s)
+			if path, err = safeJoin(path, s); err != nil {
+				return
+			}
 		}
 
 		// If serving from subDir point to it
@@ -766,7 +791,10 @@ func cloneDOC(scid, docNum, path, endpoint string, cancelled ...*atomic.Bool) (c
 		}
 	}
 
-	filePath := filepath.Join(path, recreate)
+	filePath, err := safeJoin(path, recreate)
+	if err != nil {
+		return
+	}
 	if _, err = os.Stat(filePath); !os.IsNotExist(err) {
 		err = fmt.Errorf("file %s already exists", filePath)
 		return
@@ -838,7 +866,11 @@ func cloneINDEX(scid, dURL, path, endpoint string, cancelled ...*atomic.Bool) (c
 	// TELA-INDEX entrypoint, this will be nameHdr of DOC1
 	entrypoint := ""
 	// Path where file will be stored
-	basePath := filepath.Join(path, dURL)
+	basePath, err := safeJoin(path, dURL)
+	if err != nil {
+		err = fmt.Errorf("%s %s", tagErr, err)
+		return
+	}
 	// Path to entrypoint
 	servePath := ""
 
@@ -904,7 +936,10 @@ func ConstructFromShards(docShards [][]byte, recreate, basePath, compression str
 		return
 	}
 
-	filePath := filepath.Join(basePath, recreate)
+	filePath, err := safeJoin(basePath, recreate)
+	if err != nil {
+		return
+	}
 	if _, err = os.Stat(filePath); !os.IsNotExist(err) {
 		err = fmt.Errorf("file %s already exists", filePath)
 		return
@@ -1000,7 +1035,11 @@ func CreateShardFiles(filePath, compression string, content []byte) (err error) 
 	// Check no shard files already exist
 	for i := 1; i <= totalShards; i++ {
 		name := newFileName(int(i), fileName, ext, compression)
-		newPath := filepath.Join(fileDir, name)
+		newPath, jerr := safeJoin(fileDir, name)
+		if jerr != nil {
+			err = jerr
+			return
+		}
 		if _, err = os.Stat(newPath); !os.IsNotExist(err) {
 			err = fmt.Errorf("file %s already exists", newPath)
 			return
@@ -1017,8 +1056,14 @@ func CreateShardFiles(filePath, compression string, content []byte) (err error) 
 		count++
 		name := newFileName(count, fileName, ext, compression)
 
+		var shardPath string
+		shardPath, err = safeJoin(fileDir, name)
+		if err != nil {
+			return
+		}
+
 		var shardFile *os.File
-		shardFile, err = os.Create(filepath.Join(fileDir, name))
+		shardFile, err = os.Create(shardPath)
 		if err != nil {
 			err = fmt.Errorf("failed to create %s: %s", name, err)
 			return
@@ -1101,7 +1146,11 @@ func cloneINDEXAtCommit(height int64, scid, txid, path, endpoint string, cancell
 	// TELA-INDEX entrypoint, this will be nameHdr of DOC1
 	entrypoint := ""
 	// Path where file will be stored
-	basePath := filepath.Join(path, dURL)
+	basePath, err := safeJoin(path, dURL)
+	if err != nil {
+		err = fmt.Errorf("%s %s", tagErr, err)
+		return
+	}
 	// Path to entrypoint
 	servePath := ""
 
@@ -1161,7 +1210,10 @@ func Clone(scid, endpoint string) (err error) {
 		_, err = cloneINDEX(scid, dURL, path, endpoint)
 	case "DOC":
 		// Store DOCs in respective dURL directories
-		_, err = cloneDOC(scid, "", filepath.Join(path, dURL), endpoint)
+		var docBase string
+		if docBase, err = safeJoin(path, dURL); err == nil {
+			_, err = cloneDOC(scid, "", docBase, endpoint)
+		}
 	default:
 		err = fmt.Errorf("could not validate %s as TELA INDEX or DOC", scid)
 	}


### PR DESCRIPTION
## Description

The clone and serve paths build file paths from values a smart contract fully controls, and each one reaches an `os.Create` or `os.WriteFile` with no containment.

- the dURL, read from the contract, joined as the clone base in `cloneINDEX`, `cloneINDEXAtCommit` and `Clone`'s DOC branch
- `subDir`, read from the contract, split and joined a component at a time in `cloneDOC`
- the file name from the contract's headers, joined in `cloneDOC`, in `ConstructFromShards` for the `.shards` path, and in `CreateShardFiles`

`filepath.Join` cleans `..` but does not stop the joined result from escaping its base, so none of these are contained.

Reproduced end to end on a simulator, installing an ordinary TELA INDEX and cloning it through the plain public `Clone`:

```
dURL   = ../../../../../../../tmp/telapwn-e2e
Clone(881bcd58…)  ->  no error

  /tmp/telapwn-e2e/index.html   31 bytes   "<html><body>pwned</body></html>"
```

The file lands outside the datashards directory entirely, and `Clone` returns nil. Nothing about the contract is malformed; a dURL is a free string and no install-time validation is applied to it.

### The fix

`safeJoin` joins an element onto a base and fails if the result would fall outside that base, using `filepath.Rel` rather than a string prefix test. It is applied at every site that joins a contract-controlled value onto a clone path.

The check is on escape, not on separators, so a dURL containing `/` is still legitimate. `villager/rive.js-2.35.3.shards` is a real example and still clones.

### Behaviour note

Verified against mainnet that ordinary content is unaffected: `deaddrop-library`, `telatomicswaps` and `villager` all still clone, the last of these exercising a dURL with a separator, DOCs in subdirectories, and shards. The reproduction above is now rejected with `path element "…" escapes the clone directory` and writes nothing.

`ConstructFromShards` is worth calling out separately. It is reached from `cloneDocShards` with a file name taken from the contract's headers, and it was the site most easily missed, since the traversal there arrives through `recreate` rather than through the dURL.

### Tests

`TestSafeJoin` covers the escapes (`..`, `a/../../b`, a deep relative traversal, an absolute element) and the legitimate paths that must keep working, including a dURL with a separator. `TestConstructFromShardsContainment` pins the shards site specifically, asserting both the error and that no file is planted outside the base.

Both run under a plain `go test` with no simulator. Reverting `safeJoin` to `filepath.Join` makes `TestConstructFromShardsContainment` fail and plants the file again.

### Note on the existing suite

`TestTELA` does not run to completion in my environment, and `Install`, `Exported` and `ServeTELA` fail the same way on a clean `dev`, so they are unrelated to this change. With a simulator built from the `derohe` revision this repo pins and started with `--testnet`, `Install` fails intermittently on statement and nonce verification under fast automine, and `Exported` fails on an address prefix, expecting `deto1…` and getting `dero1…`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
