### PR TITLE
fix: validate what a MOD registration actually declares

### DIFF
--- a/TELA-MOD-1/README.md
+++ b/TELA-MOD-1/README.md
@@ -125,6 +125,8 @@ if err != nil {
 }
 ```
 
+- `Mods.Add` returns an error and adds nothing if the new `MODClass` or any of its `MODs` conflict with what is already registered. The `MODClass` tag cannot be a duplicate of an existing `MODClass` tag, and it cannot prefix one or be prefixed by one, as that tag prefix is what identifies a `MOD`'s class to `GetClass` and to the `MODClass` rules. Each `MOD` requires its own name and tag, and its `FunctionNames` must name each of the functions its code defines, once each, as those are the names injected into a contract.
+
 - The new `MOD` would now be available within its `MODClass` and can be accessed by its tag.
 ```go
 Mods.GetMod("ncone")

--- a/modregistration_test.go
+++ b/modregistration_test.go
@@ -1,0 +1,135 @@
+package tela
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestVerifyMODRegistration covers what Verify accepts as a MOD registration.
+//
+// The count of a MOD's declared function names does not tie those names to its
+// code. injectMOD copies sc.Functions[name] for every declared name, so a name
+// the code does not define is injected as an empty function instead of being
+// rejected at registration.
+//
+// The MODs values here are local, so this test does not read or write the
+// package Mods variable which TestTELA adds to.
+func TestVerifyMODRegistration(t *testing.T) {
+	class := MODClass{Name: "Test class", Tag: "tc"}
+	single := `Function RealName() Uint64
+10 RETURN 0
+End Function`
+	double := `Function RealName() Uint64
+10 RETURN 0
+End Function
+
+Function OtherName() Uint64
+10 RETURN 0
+End Function`
+
+	withNames := func(names []string, code string) MODs {
+		return MODs{
+			mods: []MOD{{
+				Name:          "Test mod",
+				Tag:           class.NewTag("one"),
+				Description:   "registration test",
+				FunctionCode:  func() string { return code },
+				FunctionNames: names,
+			}},
+			classes: []MODClass{class},
+			index:   []int{1},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mods    MODs
+		wantErr bool
+	}{
+		{"names match the code", withNames([]string{"RealName"}, single), false},
+		{"declared name is not in the code", withNames([]string{"NotDefined"}, single), true},
+		{"declared names are duplicated", withNames([]string{"RealName", "RealName"}, double), true},
+		{"both names match the code", withNames([]string{"RealName", "OtherName"}, double), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mods.Verify()
+			if tt.wantErr {
+				assert.Error(t, err, "Verify should not accept a MOD where %s", tt.name)
+				return
+			}
+
+			assert.NoError(t, err, "Verify should accept a MOD where %s: %s", tt.name, err)
+		})
+	}
+}
+
+// TestVerifyMODClassTagOverlap covers class tags which prefix one another.
+//
+// A MODClass tag prefixes all of its members' tags, and both GetClass and the
+// Single MOD rule match on that prefix, so overlapping class tags make two
+// classes indistinguishable and cause the Single MOD rule to reject valid tag
+// combinations from different classes.
+func TestVerifyMODClassTagOverlap(t *testing.T) {
+	tests := []struct {
+		name    string
+		tags    []string
+		wantErr bool
+	}{
+		{"distinct tags", []string{"vs", "tx"}, false},
+		{"one tag prefixes another", []string{"vs", "v"}, true},
+		{"prefix declared first", []string{"v", "vs"}, true},
+		{"shared prefix but neither contains the other", []string{"va", "vb"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var classes []MODClass
+			var index []int
+			for i, tag := range tt.tags {
+				classes = append(classes, MODClass{Name: fmt.Sprintf("Class %d", i), Tag: tag})
+				index = append(index, 0)
+			}
+
+			m := MODs{classes: classes, index: index}
+			err := m.Verify()
+			if tt.wantErr {
+				assert.Error(t, err, "Verify should not accept class tags %v", tt.tags)
+				return
+			}
+
+			assert.NoError(t, err, "Verify should accept class tags %v: %s", tt.tags, err)
+		})
+	}
+}
+
+// TestMODsRegisteredAtInit covers what initMods left registered.
+//
+// Add adds nothing when any part of what it is given conflicts, so one bad
+// entry drops a whole MODClass and every MOD in it, and the Verify below passes
+// because what remains is consistent. Both Add calls report that now, but the
+// registration itself is built from literals with no seam a test can fail, so
+// this pins the result rather than the report.
+//
+// Only presence is asserted, which is what a silent drop takes away. Anything
+// registered afterwards is additive and does not affect it.
+func TestMODsRegisteredAtInit(t *testing.T) {
+	for _, tag := range []string{"vs", "tx"} {
+		var found bool
+		for _, c := range Mods.GetAllClasses() {
+			if c.Tag == tag {
+				found = true
+				break
+			}
+		}
+
+		assert.True(t, found, "MODClass %q was not registered", tag)
+	}
+
+	for _, tag := range []string{"vsoo", "vsooim", "vspubsu", "vspubow", "vspubim", "txdwd", "txdwa", "txto"} {
+		assert.NotEmpty(t, Mods.GetMod(tag).Name, "MOD %q was not registered", tag)
+	}
+}

--- a/mods.go
+++ b/mods.go
@@ -224,7 +224,9 @@ func initMods() {
 		}
 
 		// Add the variable store MODClass and its MODs
-		Mods.Add(variableStoreMODClass, variableStoreMODs)
+		if err := Mods.Add(variableStoreMODClass, variableStoreMODs); err != nil {
+			logger.Fatalf("[TELA] MODs: %s\n", err)
+		}
 	}
 
 	// // Transfers MODClass
@@ -261,7 +263,9 @@ func initMods() {
 		}
 
 		// Add the transfers MODClass and its MODs
-		Mods.Add(transferMODClass, transferMODs)
+		if err := Mods.Add(transferMODClass, transferMODs); err != nil {
+			logger.Fatalf("[TELA] MODs: %s\n", err)
+		}
 	}
 
 	// This is checked each Add but we should ensure again there is no conflicts with the initialized MODClasses and MODs
@@ -307,6 +311,16 @@ func (m *MODs) Verify() (err error) {
 		return
 	}
 
+	// A MODClass tag prefixes all of its members' tags, and both GetClass and the
+	// Single MOD rule match on that prefix. If one class tag prefixes another the
+	// two classes are indistinguishable at lookup, and the Single MOD rule counts
+	// the other class's MODs as its own, rejecting valid tag combinations.
+	prefix, of, found := hasPrefixOverlap(classTags)
+	if found {
+		err = fmt.Errorf("class tag %q cannot prefix class tag %q", prefix, of)
+		return
+	}
+
 	if len(m.classes) != len(m.index) {
 		err = fmt.Errorf("invalid MODClass index: %d/%d", len(m.classes), len(m.index))
 		return
@@ -334,6 +348,22 @@ func (m *MODs) Verify() (err error) {
 		if len(mod.FunctionNames) != len(sc.Functions) {
 			err = fmt.Errorf("missing function names for %q  %d/%d", mod.Name, len(mod.FunctionNames), len(sc.Functions))
 			return
+		}
+
+		// The count alone does not tie the declared names to the code. injectMOD
+		// copies sc.Functions[name] for each declared name, so a name the code
+		// does not define injects an empty function rather than failing here.
+		duplicate, found = hasDuplicateString(mod.FunctionNames)
+		if found {
+			err = fmt.Errorf("function name %q for %q cannot be duplicated", duplicate, mod.Name)
+			return
+		}
+
+		for _, name := range mod.FunctionNames {
+			if _, ok := sc.Functions[name]; !ok {
+				err = fmt.Errorf("function name %q for %q is not defined in its code", name, mod.Name)
+				return
+			}
 		}
 
 		modTags = append(modTags, mod.Tag)
@@ -400,6 +430,24 @@ func hasDuplicateString(check []string) (duplicate string, found bool) {
 		}
 
 		have[ele] = true
+	}
+
+	return
+}
+
+// Check if any element is a prefix of another element, in either direction.
+// Duplicates are reported by hasDuplicateString and should be checked first
+func hasPrefixOverlap(check []string) (prefix, of string, found bool) {
+	for i, a := range check {
+		for j, b := range check {
+			if i == j {
+				continue
+			}
+
+			if strings.HasPrefix(b, a) {
+				return a, b, true
+			}
+		}
 	}
 
 	return

--- a/tela_test.go
+++ b/tela_test.go
@@ -2403,8 +2403,8 @@ func TestTELA(t *testing.T) {
 				Rules: []MODClassRule{},
 			},
 			[]MOD{
-				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}}, // duplicate mod tags
-				{Name: "MOD2", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}},
+				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}}, // duplicate mod tags
+				{Name: "MOD2", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}},
 			},
 		)
 		assert.Error(t, err, "Adding MODs with duplicate tags should error")
@@ -2416,8 +2416,8 @@ func TestTELA(t *testing.T) {
 				Rules: []MODClassRule{},
 			},
 			[]MOD{
-				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}}, // duplicate mod names
-				{Name: "MOD1", Tag: "nc2", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}},
+				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}}, // duplicate mod names
+				{Name: "MOD1", Tag: "nc2", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}},
 			},
 		)
 		assert.Error(t, err, "Adding MODs with duplicate names should error")
@@ -2439,8 +2439,8 @@ func TestTELA(t *testing.T) {
 				Rules: []MODClassRule{},
 			},
 			[]MOD{
-				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}},
-				{Name: "MOD2", Tag: "nc2", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"Name1", "Name2"}},
+				{Name: "MOD1", Tag: "nc1", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}},
+				{Name: "MOD2", Tag: "nc2", FunctionCode: func() string { return TELA_MOD_1_TXTO }, FunctionNames: []string{"TransferOwnership", "ClaimOwnership"}},
 			},
 		)
 		assert.NoError(t, err, "Adding a valid MODClass and MOD should not error: %s", err)


### PR DESCRIPTION
## Description

`Verify` compared the *number* of a MOD's declared `FunctionNames` against the number of functions its code parses to. A count does not tie the names to the code, so a MOD declaring a function its code does not define was accepted:

```
FunctionNames: []string{"SetVar", "DeletVar"}   // code defines SetVar, DeleteVar
                                 ^ typo         // 2 == 2, accepted
```

`injectMOD` then runs `modSC.Functions[name] = sc.Functions[name]` for every declared name, so the typo stores an *empty* function on the contract rather than failing, and the MOD is registered as providing something it does not.

This adds three checks to `Verify`:

- a declared name absent from the MOD's own code
- duplicated declared names, which the count check alone lets through in pairs
- `MODClass` tags where one is a prefix of another

### Why the class tag check

A `MODClass` tag prefixes all of its members' tags, and both `GetClass` and the Single MOD rule match on that prefix. Duplicate class tags were rejected, overlapping ones were not, and either direction breaks something:

- registering a class tagged `"v"` alongside the existing `"vs"` makes the Single MOD rule count the variable store MODs as its own, so `TagsAreValid` returns a conflict for two MODs belonging to two different classes
- registering one tagged `"vso"` instead leaves its own MODs shadowed by `"vs"` at lookup, so `GetClass` attributes them to the variable store class

Only class tags are checked against each other here. A MOD tag which does not begin with its own class tag is a separate gap, and closing it needs the `MODClass` index `Add` builds, which does not line its classes up with its MODs.

### The discarded `Add` error

`initMods` discarded the error from both `Mods.Add` calls. `Add` is atomic, so a single bad entry drops the whole `MODClass` and every MOD in it, and the `Mods.Verify` below then passes because what remains is consistent. Reproduced on a clean `dev` through the duplicate tag route: the package boots with five MODs missing and `TagsAreValid` answering ``tag "vsoo" does not exist``.

That is pre-existing. The checks added here widen it to a mistyped function name, which is the likeliest way in, so both `Add` calls now `logger.Fatalf` like the `Mods.Verify` immediately below them and a contributor sees the name they got wrong.

### Behaviour note

All eight MODs the package ships pass the stricter checks unchanged, and the existing class tags `"vs"` and `"tx"` do not overlap. The install and update code generated for all 48 valid `modTag` combinations, and the contract versions validation compares against, are byte identical before and after, so nothing on chain is affected.

What does change is `Mods.Add`, which is exported and which `TELA-MOD-1/README.md` invites third parties to call. A registration that is now rejected previously returned `nil` and registered a MOD that could not do what it declared. Ticked as a patch on that basis, and because the sibling fix in #11 changes an exported return the same way — happy to re-tick as major if you read it differently.

### Documentation

`TELA-MOD-1/README.md` walks contributors through `Mods.Add`, and enforcement is now fatal at import, so the README should not be silent about what `Add` requires. One paragraph added at the point in *Adding New MODs* where the reader is handed `Mods.Add`.

### Tests

`TestVerifyMODRegistration` and `TestVerifyMODClassTagOverlap` are table driven over local `MODs` values, so they neither read nor write the package `Mods` variable that `TestTELA/MODs` adds to. Both run under a plain `go test` with no simulator. Reverting each check fails only its own cases: the not-defined check fails `/declared_name_is_not_in_the_code`, the duplicate check fails `/declared_names_are_duplicated`, the prefix check fails `/one_tag_prefixes_another` and `/prefix_declared_first`.

The `initMods` change is the exception and I would rather say so than have you find it. Those registrations are literals, so there is no seam a test can make `Add` fail through, and no test fails when that change alone is reverted. `TestMODsRegisteredAtInit` pins its result instead — both `MODClass`es and all eight MODs still registered after import, which is exactly what a silent drop takes away. Mistyping one shipped `FunctionName` fails that test with five MODs missing without the change, and aborts at import naming the typo with it.

Also in this branch: the MODs `TestTELA/MODs` registers declared placeholder names (`"Name1"`, `"Name2"`) their code does not define, so they now declare the real `TXTO` functions. Without that, the subtest's own valid-`Add` assertion fails and the duplicate tag and duplicate name cases stop failing for the reason they are named after.

### Note on the existing suite

`TestTELA` does not run to completion in my environment, failing at `tela_test.go:2902` on the simulator connection, and it fails identically on a clean `dev`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [x] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [x] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
