### PR TITLE
fix: refuse to inject a MOD function the contract already defines

### DIFF
--- a/injectmod_test.go
+++ b/injectmod_test.go
@@ -1,0 +1,100 @@
+package tela
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInjectMODRefusesExistingFunction covers injecting a MOD whose function
+// name the contract already defines.
+//
+// The MOD's code is appended to the contract as text while its functions are
+// set on the parsed contract, so overwriting produced a contract carrying two
+// definitions of the same function. That parses, the MOD's body silently
+// replaces the contract's own, and the served code carries a dead duplicate.
+//
+// The shipped tags are listed here rather than read from the package Mods
+// variable, which keeps this test independent of anything registered at runtime.
+func TestInjectMODRefusesExistingFunction(t *testing.T) {
+	// The collision is on DeleteVar, the second name vsoo declares, so a
+	// refusal which injected as it went would have already set SetVar
+	base := `Function Initialize() Uint64
+10 RETURN 0
+End Function
+
+Function DeleteVar(k String) Uint64
+10 RETURN 77
+End Function`
+
+	modSC, _, err := Mods.injectMOD("vsoo", base)
+	assert.Error(t, err, "injectMOD overwrote a function the contract already defined")
+	_, injected := modSC.Functions["SetVar"]
+	assert.False(t, injected, "refused MOD should not leave SetVar on the returned contract")
+
+	_, _, err = Mods.InjectMODs("vsoo", base)
+	assert.Error(t, err, "InjectMODs overwrote a function the contract already defined")
+
+	// Every MOD the package ships must still inject into the INDEX template
+	shipped := []string{"vsoo", "vsooim", "vspubsu", "vspubow", "vspubim", "txdwd", "txdwa", "txto"}
+	for _, tag := range shipped {
+		_, _, err = Mods.InjectMODs(tag, TELA_INDEX_1)
+		assert.NoError(t, err, "MOD %q no longer injects into TELA-INDEX-1: %s", tag, err)
+	}
+
+	// The transfers MODClass is Multi MOD, so its members combine with a
+	// variable store MOD in one contract and must not collide with each other
+	combined := NewModTag([]string{"vsoo", "txdwd", "txdwa", "txto"})
+	_, _, err = Mods.InjectMODs(combined, TELA_INDEX_1)
+	assert.NoError(t, err, "valid MOD combination %q no longer injects: %s", combined, err)
+}
+
+// TestInjectMODRefusesUndeclaredFunction covers a MOD whose code defines a name
+// it does not declare.
+//
+// The whole code set is appended to the contract as text, not only the declared
+// functions, so a name the code defines but does not declare lands in the
+// contract just the same. Checking the declared names alone would leave the
+// contract carrying two definitions of it.
+//
+// The MODs value here is local, so this test does not read or write the package
+// Mods variable.
+func TestInjectMODRefusesUndeclaredFunction(t *testing.T) {
+	class := MODClass{Name: "Test class", Tag: "tc"}
+	m := MODs{
+		mods: []MOD{{
+			Name:        "Test mod",
+			Tag:         class.NewTag("one"),
+			Description: "injection test",
+			FunctionCode: func() string {
+				return `Function Declared() Uint64
+10 RETURN 0
+End Function
+
+Function Undeclared() Uint64
+10 RETURN 0
+End Function`
+			},
+			FunctionNames: []string{"Declared"},
+		}},
+		classes: []MODClass{class},
+		index:   []int{1},
+	}
+
+	base := `Function Undeclared() Uint64
+10 RETURN 77
+End Function`
+
+	_, _, err := m.injectMOD("tcone", base)
+	assert.Error(t, err, "injectMOD appended a second definition of a function the contract already defined")
+
+	// A declared name the MOD's code does not define is injected as an empty
+	// function, so it overwrites the contract's own just the same
+	m.mods[0].FunctionNames = []string{"Declared", "NotInTheCode"}
+	base = `Function NotInTheCode() Uint64
+10 RETURN 77
+End Function`
+
+	_, _, err = m.injectMOD("tcone", base)
+	assert.Error(t, err, "injectMOD overwrote a function with an empty one")
+}

--- a/mods.go
+++ b/mods.go
@@ -2,6 +2,7 @@ package tela
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/civilware/tela/logger"
@@ -466,6 +467,27 @@ func (m *MODs) TagsAreValid(modTag string) (tags []string, err error) {
 	return
 }
 
+// Names which injecting a MOD would put into a contract, being the ones it declares
+// and the ones its code defines. The result is sorted so a refusal is deterministic
+func injectedNames(functionNames []string, sc dvm.SmartContract) (names []string) {
+	have := map[string]bool{}
+	for _, name := range functionNames {
+		have[name] = true
+	}
+
+	for name := range sc.Functions {
+		have[name] = true
+	}
+
+	for name := range have {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return
+}
+
 // injectMOD injects a TELA-MOD's functions into the code of a smart contract and returns the new smart contract and new code
 func (m *MODs) injectMOD(mod, code string) (modSC dvm.SmartContract, modCode string, err error) {
 	modSC, _, err = dvm.ParseSmartContract(code)
@@ -485,6 +507,22 @@ func (m *MODs) injectMOD(mod, code string) (modSC dvm.SmartContract, modCode str
 	if err != nil {
 		err = fmt.Errorf("could not parse MOD %q code: %s", mod, err)
 		return
+	}
+
+	// A name the contract already defines is refused rather than overwritten.
+	// The injected code is appended as text while the functions are set on the
+	// parsed contract, so overwriting produced a contract carrying two
+	// definitions of the same function, which parses and silently keeps one.
+	// The names the MOD's code defines are checked as well as the ones it
+	// declares, because the whole code set is what gets appended, and a
+	// declared name its code does not define still overwrites the contract's
+	// function with an empty one. This is checked before injecting anything so
+	// a refused MOD does not leave its earlier functions on the returned contract
+	for _, name := range injectedNames(functionNames, sc) {
+		if _, exists := modSC.Functions[name]; exists {
+			err = fmt.Errorf("MOD %q function %q is already defined in this contract", mod, name)
+			return
+		}
 	}
 
 	// Inject the new MOD functions into the smart contract


### PR DESCRIPTION
## Description

`injectMOD` sets each of a MOD's functions on the parsed contract with a plain map write, while appending the MOD's code to the contract as text:

```go
for _, name := range functionNames {
        modSC.Functions[name] = sc.Functions[name]
}

modCode = fmt.Sprintf("%s\n%s", code, modCodeSet)
```

Injecting a MOD into a contract which already defines one of those names therefore produces a contract carrying two definitions of the same function. That parses, the MOD's body silently replaces the contract's own, and the served code carries a dead duplicate of a function which no longer runs.

The names are now checked against the contract before any of them is set, so a refused MOD appends no code and leaves none of its own functions on the contract `injectMOD` returns. Checking before rather than during matters for the second and later names a MOD declares — `vsoo` declares `SetVar` then `DeleteVar`, and refusing at `DeleteVar` after setting `SetVar` would hand back a half injected contract alongside the error.

### Which names are checked

The declared names and the ones the MOD's code defines. For the eight MODs shipped here those are the same set, but they are not the same thing in general, and either one alone leaves the defect open:

- the whole code set is appended as text, so a name the code defines without declaring lands in the contract regardless
- a declared name the code does not define is set on the parsed contract as an empty function, overwriting whatever was there

Measured on this branch before that was widened: a MOD whose code defines `Rate` while declaring some other name registers fine, injects without error, and produces an INDEX with two `Function Rate(` in it that `ValidINDEXVersion` accepts as `1.1.0`. With the widened check it is refused.

### Behaviour note

Every path in this package which reaches `injectMOD` starts from the untouched `TELA-INDEX-1` template. `NewInstallArgs` and `NewUpdateArgs` both inject into it, and `createContractVersions` only injects into the version it just built. The install and update code generated for all 48 valid `modTag` combinations, and the contract versions validation compares against, are byte identical before and after this change, as is `ValidINDEXVersion`'s answer for each. No contract which validates today can start failing to validate.

What does change is the exported `InjectMODs` for a caller passing already injected code. That returned a contract with duplicate definitions and now returns an error. Ticked as a patch on that basis, and because #11 changes an exported return the same way — happy to re-tick as major if you read it differently.

### Interaction with #11

#11 touches the same function. They merge with no conflict, the merged tree builds, and both tests here pass on it. There is no semantic overlap: #11 changes what `InjectMODs` *returns*, this changes when `injectMOD` *errors*. The pre-pass is worth having under #11 specifically, since #11 propagates the contract out of `InjectMODs` and a mid-loop refusal would propagate a half injected one.

### Tests

`TestInjectMODRefusesExistingFunction` injects `vsoo` into a contract already defining `DeleteVar`, the *second* name `vsoo` declares, and asserts both the error and that `SetVar` is absent from the returned contract, which is the no-partial-state invariant rather than an incidental. It then asserts every shipped tag still injects into `TELA-INDEX-1` and that `"vsoo,txdwd,txdwa,txto"` still injects as one contract. The shipped tags are listed literally rather than read from the package `Mods` variable, so the test is independent of anything registered at runtime.

`TestInjectMODRefusesUndeclaredFunction` covers the two routes above over a local `MODs` value.

Both run under a plain `go test` with no simulator. Reverting the check fails them and nothing else.

### Note on the existing suite

`TestTELA` does not run to completion in my environment, failing at `tela_test.go:2902` on the simulator connection, and it fails identically on a clean `dev`.

## Type of change

Please select the right one.

- [x] (Patch) Bug fix (non-breaking change which fixes an issue)
- [ ] (Minor) New feature (non-breaking change which adds functionality)
- [ ] (Major) Breaking change (modification that would disrupt existing functionality and require changes to maintain expected behavior)
- [ ] This change requires a documentation update

## Which package(s) are impacted ?

- [ ] cmd
- [x] tela
- [ ] shards
- [ ] logger
- [ ] Misc (documentation, etc...)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code
- [x] I have test coverage for my changes
- [x] My changes generate no new warnings

## License

I am contributing & releasing the code under the [MIT License](https://raw.githubusercontent.com/civilware/tela/main/LICENSE).
